### PR TITLE
docker user for cpp_format_tools

### DIFF
--- a/cpp_format_tools/README.md
+++ b/cpp_format_tools/README.md
@@ -12,5 +12,5 @@ with all dependencies and tools built-in, to format C++ code.
 ## Usage
 
 ```bash
-docker run --rm --privileged=true --volume ${PWD}:/otel otel/cpp_format_tools
+docker run --rm --user "$(id -u):$(id -g)" --volume ${PWD}:/otel otel/cpp_format_tools
 ```


### PR DESCRIPTION
Fixes file permission change after using `cpp_format_tools`
by running the container with the current user id and group id we can avoid file permission change after running the script.