### PR TITLE
[DOC] Cleanup after migration from build-tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For anything not explicitly taken by someone else:
+*       @open-telemetry/cpp-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-*       @open-telemetry/cpp-approvers
+*       @open-telemetry/cpp-maintainers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Guideline to update the version
+
+Increment the:
+
+* MAJOR version when you make incompatible API/ABI changes,
+* MINOR version when you add functionality in a backwards compatible manner, and
+* PATCH version when you make backwards compatible bug fixes.
+
+## [Unreleased]
+
+* TITLE
+
+## [0.0] 2024-02-16
+
+* Migrated from https://github.com/open-telemetry/build-tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,19 +16,14 @@ please make sure to add an entry for your change in the "Unreleased" section.
 ## Release instructions for maintainers
 
 1. Add new desired version number in all `CHANGELOG.md` files (instead of "Unreleased") and ensure no (relevant) entries are missing
-   - This currently applies to [semantic-conventions/CHANGELOG.md](./semantic-conventions/CHANGELOG.md)
-     and [schemas/CHANGELOG.md](./schemas/CHANGELOG.md).
-2. Create the release at <https://github.com/open-telemetry/build-tools/releases/new>
+2. Create the release at <https://github.com/open-telemetry/cpp-build-tools/releases/new>
    1. Tag: `v0.xx.y`
    2. Title: `Release version 0.xx.y`
    3. Click on _Generate release notes_
    4. Structure release notes with the headings used in former release notes (since one release applies to multiple distinct components)
    5. Verify that the release looks like expected and hit _Publish release_
 3. Verify the release
-   - Ensure all workflows in <https://github.com/open-telemetry/build-tools/actions> succeeded (branch = the new version tag)
+   - Ensure all workflows in <https://github.com/open-telemetry/cpp-build-tools/actions> succeeded (branch = the new version tag)
    - Ensure all images were pushed to <https://hub.docker.com/u/otel> as expected. Currently these are:
-     - <https://hub.docker.com/r/otel/semconvgen/tags>
-     - <https://hub.docker.com/r/otel/build-tool-schemas/tags>
-     - <https://hub.docker.com/r/otel/build-protobuf/tags>
      - <https://hub.docker.com/r/otel/cpp_format_tools/tags>
 4. Update the respective version references in the <https://github.com/open-telemetry/opentelemetry-specification> repository, if needed

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ _Find more about the approver role in [community repository](https://github.com/
 
 ### Maintainers
 
-- OpenTelemetry C++ Maintainers ([@open-telemetry/cpp-maintainers](https://github.com/orgs/open-telemetry/teams/cpp-approvers))
+- OpenTelemetry C++ Maintainers ([@open-telemetry/cpp-maintainers](https://github.com/orgs/open-telemetry/teams/cpp-maintainers))
 
 _Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer)._


### PR DESCRIPTION
Remove references to build-tools.
Remove references to tooling not part of this repository.
Add CHANGELOG.
Add CODEOWNERS.
Fix maintainers URL.