### PR TITLE
[CI] Upgrade to clang-format-18

### DIFF
--- a/cpp_format_tools/Dockerfile
+++ b/cpp_format_tools/Dockerfile
@@ -1,20 +1,21 @@
 ARG BUILDIFIER_VERSION=3.5.0
-ARG CLANG_VERSION=10.0.1-r0
+ARG CLANG_VERSION=18
 ARG CMAKE_FORMAT_VERSION=0.6.13
 
-FROM alpine:3.13
+FROM ubuntu:24.04
 LABEL maintainer="The OpenTelemetry Authors"
-RUN apk update
+RUN apt update
 
 ARG CLANG_VERSION
-RUN apk add --no-cache clang=${CLANG_VERSION} python3 py3-pip git curl
+RUN apt install -y clang-format-${CLANG_VERSION} python3 python3-pip git curl \
+    && ln /usr/bin/clang-format-${CLANG_VERSION} /usr/bin/clang-format
 
 ARG CMAKE_FORMAT_VERSION
-RUN pip3 install cmake_format==${CMAKE_FORMAT_VERSION}
+RUN pip3 install --break-system-packages cmake_format==${CMAKE_FORMAT_VERSION}
 
 ARG BUILDIFIER_VERSION
 RUN curl -L -o /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${BUILDIFIER_VERSION}/buildifier
 RUN chmod +x /usr/local/bin/buildifier
 
 COPY format.sh /
-ENTRYPOINT ["sh", "/format.sh"]
+ENTRYPOINT ["bash", "/format.sh"]

--- a/cpp_format_tools/format.sh
+++ b/cpp_format_tools/format.sh
@@ -1,23 +1,59 @@
 #!/bin/bash
 
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
-FIND="find /otel -name third_party -prune -o -name tools -prune -o -name .git -prune -o -name _deps -prune -o -name .build -prune -o -name out -prune -o -name .vs -prune -o"
+FIND="find /otel -name third_party -prune -o -name tools -prune -o -name .git -prune -o -name _deps -prune -o -name .build -prune -o -name out -prune -o -name .vs -prune -o -name opentelemetry_logo.png -prune -o -name TraceLoggingDynamic.h -prune -o"
 
-echo "Running sed: "
-echo "-> Correct common miscapitalizations."
-sed -i 's/Open[t]elemetry/OpenTelemetry/g' $($FIND -type f -print)
-echo "-> No CRLF line endings, except Windows files."
-sed -i 's/\r$//' $($FIND -name '*.ps1' -prune -o \
+# GNU syntax.
+SED=(sed -i)
+if [[ "$(uname)" = "Darwin" ]]; then
+  SED=(sed -i "")
+fi
+
+# Correct common miscapitalizations.
+"${SED[@]}" 's/Open[t]elemetry/OpenTelemetry/g' $($FIND -type f -print)
+# No CRLF line endings, except Windows files.
+"${SED[@]}" 's/\r$//' $($FIND -name '*.ps1' -prune -o \
   -name '*.cmd' -prune -o -type f -print)
-echo "-> No trailing spaces."
-sed -i 's/ \+$//' $($FIND -type f -print)
+# No trailing spaces.
+"${SED[@]}" 's/ \+$//' $($FIND -type f -print)
 
-echo "Running clang-format $(clang-format --version 2>&1)."
-clang-format -i -style=file $($FIND -name '*.cc' -print -o -name '*.h' -print)
+# If not overridden, try to use clang-format-10 or clang-format.
+if [[ -z "$CLANG_FORMAT" ]]; then
+  CLANG_FORMAT=clang-format
+  if which clang-format-18 >/dev/null; then
+    CLANG_FORMAT=clang-format-18
+  fi
+fi
 
-echo "Running cmake-format $(cmake-format --version 2>&1)."
-cmake-format -i $($FIND -name 'CMakeLists.txt' -print -name '*.cmake' -print -name '*.cmake.in' -print)
+$CLANG_FORMAT -version
+$CLANG_FORMAT -i -style=file \
+  $($FIND -name '*.cc' -print -o -name '*.h' -print)
 
-echo "Running buildifier"
-buildifier $($FIND -name WORKSPACE -print -o -name BUILD -print -o -name '*.BUILD' -o -name '*.bzl' -print)
+if which cmake-format >/dev/null; then
+  echo "Running cmake-format $(cmake-format --version 2>&1)."
+  cmake-format -i $($FIND -name 'CMakeLists.txt' -print -name '*.cmake' -print -name '*.cmake.in' -print)
+else
+  echo "Can't find cmake-format. It can be installed with:"
+  echo "  pip install --user cmake_format"
+  exit 1
+fi
+
+if [[ -z "$BUILDIFIER" ]]; then
+  BUILDIFIER="$HOME/go/bin/buildifier"
+  if ! which "$BUILDIFIER" >/dev/null; then
+    BUILDIFIER=buildifier
+  fi
+fi
+if which "$BUILDIFIER" >/dev/null; then
+  echo "Running $BUILDIFIER"
+  "$BUILDIFIER" $($FIND -name WORKSPACE -print -o -name BUILD -print -o \
+    -name '*.BUILD' -o -name '*.bzl' -print)
+else
+  echo "Can't find buildifier. It can be installed with:"
+  echo "  go get github.com/bazelbuild/buildtools/buildifier"
+  exit 1
+fi

--- a/cpp_format_tools/format.sh
+++ b/cpp_format_tools/format.sh
@@ -21,7 +21,7 @@ fi
 # No trailing spaces.
 "${SED[@]}" 's/ \+$//' $($FIND -type f -print)
 
-# If not overridden, try to use clang-format-10 or clang-format.
+# If not overridden, try to use clang-format-18 or clang-format.
 if [[ -z "$CLANG_FORMAT" ]]; then
   CLANG_FORMAT=clang-format
   if which clang-format-18 >/dev/null; then


### PR DESCRIPTION
upgrades to clang-format-18 which is shipped with Ubuntu:24.04
fixes https://github.com/open-telemetry/opentelemetry-cpp/issues/2578