### PR TITLE
[FORMAT] Do not format .diff and .patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Increment the:
 
 ## [Unreleased]
 
-* TITLE
+* [FORMAT] Do not format .diff and .patch
+  [#10](https://github.com/open-telemetry/cpp-build-tools/pull/10)
 
 ## [0.0] 2024-02-16
 

--- a/cpp_format_tools/format.sh
+++ b/cpp_format_tools/format.sh
@@ -18,8 +18,8 @@ fi
 # No CRLF line endings, except Windows files.
 "${SED[@]}" 's/\r$//' $($FIND -name '*.ps1' -prune -o \
   -name '*.cmd' -prune -o -type f -print)
-# No trailing spaces.
-"${SED[@]}" 's/ \+$//' $($FIND -type f -print)
+# No trailing spaces, except in patch.
+"${SED[@]}" 's/ \+$//' $($FIND -name "*.patch" -prune -o -type f -print)
 
 # If not overridden, try to use clang-format-18 or clang-format.
 if [[ -z "$CLANG_FORMAT" ]]; then

--- a/cpp_format_tools/format.sh
+++ b/cpp_format_tools/format.sh
@@ -18,8 +18,8 @@ fi
 # No CRLF line endings, except Windows files.
 "${SED[@]}" 's/\r$//' $($FIND -name '*.ps1' -prune -o \
   -name '*.cmd' -prune -o -type f -print)
-# No trailing spaces, except in patch.
-"${SED[@]}" 's/ \+$//' $($FIND -name "*.patch" -prune -o -type f -print)
+# No trailing spaces, except in diff or patch.
+"${SED[@]}" 's/ \+$//' $($FIND -name "*.diff" -prune -o -name "*.patch" -prune -o -type f -print)
 
 # If not overridden, try to use clang-format-18 or clang-format.
 if [[ -z "$CLANG_FORMAT" ]]; then


### PR DESCRIPTION
This is a backport from:

* https://github.com/open-telemetry/opentelemetry-cpp/pull/3002

## Changes

Please provide a brief description of the changes here.

* Fixed script format.sh to ignore *.diff and *.patch files