### PR TITLE
Don't rely on github team links which aren't visible to external contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ### Maintainers
 
-- OpenTelemetry C++ Maintainers ([@open-telemetry/cpp-maintainers](https://github.com/orgs/open-telemetry/teams/cpp-maintainers))
+- [OpenTelemetry C++ Maintainers](https://github.com/open-telemetry/opentelemetry-cpp#maintainers)
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
 
 ### Approvers
 
-- OpenTelemetry C++ Approvers ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers))
+- [OpenTelemetry C++ Approvers](https://github.com/open-telemetry/opentelemetry-cpp#maintainers)
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).
-
-_Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer)._


### PR DESCRIPTION
Related to https://github.com/open-telemetry/community/issues/2830