### PR TITLE
[FORMAT] Do not format shelltest

### DIFF
--- a/cpp_format_tools/format.sh
+++ b/cpp_format_tools/format.sh
@@ -18,8 +18,8 @@ fi
 # No CRLF line endings, except Windows files.
 "${SED[@]}" 's/\r$//' $($FIND -name '*.ps1' -prune -o \
   -name '*.cmd' -prune -o -type f -print)
-# No trailing spaces, except in diff or patch.
-"${SED[@]}" 's/ \+$//' $($FIND -name "*.diff" -prune -o -name "*.patch" -prune -o -type f -print)
+# No trailing spaces, except in diff, patch and shelltest.
+"${SED[@]}" 's/ \+$//' $($FIND -name "*.diff" -prune -o -name "*.patch" -prune -o -name "*.test" -prune -o -type f -print)
 
 # If not overridden, try to use clang-format-18 or clang-format.
 if [[ -z "$CLANG_FORMAT" ]]; then


### PR DESCRIPTION
Do not format `*.test` files, used by shelltest.